### PR TITLE
Support AWS Signature Version 4 (Refactored)

### DIFF
--- a/include/leo_s3_auth.hrl
+++ b/include/leo_s3_auth.hrl
@@ -53,7 +53,7 @@
           query_str     = <<>> :: binary(),
           sub_resource  = <<>> :: binary(), %% [?acl" | "?location" | "?logging" | "?torrent"]
           sign_ver      = v2   :: aws_sign_ver(),   %% [v2 | v4]
-          req                  :: cowboy_req:req(),
+          headers       = []   :: list(),
           amz_headers   = []   :: list()
          }).
 

--- a/include/leo_s3_auth.hrl
+++ b/include/leo_s3_auth.hrl
@@ -39,6 +39,7 @@
           provider = [] :: list()  %% auth-info provides
          }).
 
+-type aws_sign_ver()    :: v2 | v4.
 %% @doc AMZ-S3-API related
 %%
 -record(sign_params, {
@@ -51,7 +52,7 @@
           requested_uri = <<>> :: binary(),
           query_str     = <<>> :: binary(),
           sub_resource  = <<>> :: binary(), %% [?acl" | "?location" | "?logging" | "?torrent"]
-          sign_ver      = v2   :: atom(),   %% [v2 | v4]
+          sign_ver      = v2   :: aws_sign_ver(),   %% [v2 | v4]
           req                  :: cowboy_req:req(),
           amz_headers   = []   :: list()
          }).

--- a/include/leo_s3_auth.hrl
+++ b/include/leo_s3_auth.hrl
@@ -51,6 +51,8 @@
           requested_uri = <<>> :: binary(),
           query_str     = <<>> :: binary(),
           sub_resource  = <<>> :: binary(), %% [?acl" | "?location" | "?logging" | "?torrent"]
+          sign_ver      = v2   :: atom(),   %% [v2 | v4]
+          req                  :: cowboy_req:req(),
           amz_headers   = []   :: list()
          }).
 

--- a/include/leo_s3_auth.hrl
+++ b/include/leo_s3_auth.hrl
@@ -57,3 +57,7 @@
           amz_headers   = []   :: list()
          }).
 
+-record(sign_v4_params, {credential     :: binary(),
+                         signature      :: binary(),
+                         signed_headers :: binary()
+                        }).

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 
 {deps, [
     {cowlib,      ".*", {git, "https://github.com/extend/cowlib.git",           {tag, "1.0.0"}}},
-    {leo_commons, ".*", {git, "https://github.com/windkit/leo_commons.git", {branch, "develop"}}},
+    {leo_commons, ".*", {git, "https://github.com/leo-project/leo_commons.git", {branch, "develop"}}},
     {meck,        ".*", {git, "https://github.com/eproxus/meck.git",            {tag, "0.8.2"}}}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -25,6 +25,7 @@
 {deps, [
     {cowlib,      ".*", {git, "https://github.com/extend/cowlib.git",           {tag, "1.0.0"}}},
     {leo_commons, ".*", {git, "https://github.com/leo-project/leo_commons.git", {tag, "1.1.2"}}},
+    {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.1.6"}}},
     {meck,        ".*", {git, "https://github.com/eproxus/meck.git",            {tag, "0.8.2"}}}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 
 {deps, [
     {cowlib,      ".*", {git, "https://github.com/extend/cowlib.git",           {tag, "1.0.0"}}},
-    {leo_commons, ".*", {git, "https://github.com/windkit/leo_commons.git", {branch, "sign_v4"}}},
+    {leo_commons, ".*", {git, "https://github.com/windkit/leo_commons.git", {branch, "develop"}}},
     {meck,        ".*", {git, "https://github.com/eproxus/meck.git",            {tag, "0.8.2"}}}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 
 {deps, [
     {cowlib,      ".*", {git, "https://github.com/extend/cowlib.git",           {tag, "1.0.0"}}},
-    {leo_commons, ".*", {git, "https://github.com/leo-project/leo_commons.git", {tag, "1.1.2"}}},
+    {leo_commons, ".*", {git, "https://github.com/windkit/leo_commons.git", {branch, "sign_v4"}}},
     {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.1.6"}}},
     {meck,        ".*", {git, "https://github.com/eproxus/meck.git",            {tag, "0.8.2"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,6 @@
 {deps, [
     {cowlib,      ".*", {git, "https://github.com/extend/cowlib.git",           {tag, "1.0.0"}}},
     {leo_commons, ".*", {git, "https://github.com/windkit/leo_commons.git", {branch, "sign_v4"}}},
-    {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.1.6"}}},
     {meck,        ".*", {git, "https://github.com/eproxus/meck.git",            {tag, "0.8.2"}}}
 ]}.
 

--- a/src/leo_s3_auth.erl
+++ b/src/leo_s3_auth.erl
@@ -243,9 +243,9 @@ has_credential(MasterNodes, AccessKey) ->
 %% @doc Authenticate
 %%
 -spec(authenticate(Authorization, SignParams, IsCreateBucketOp) ->
-             {ok, binary()} | {error, any()} when Authorization::binary(),
-                                                  SignParams::#sign_params{},
-                                                  IsCreateBucketOp::boolean()).
+             {ok, binary(), binary()} | {error, any()} when Authorization::binary(),
+                                                            SignParams::#sign_params{},
+                                                            IsCreateBucketOp::boolean()).
 authenticate(Authorization, #sign_params{sign_ver = SignVer} = SignParams, IsCreateBucketOp) ->
     {AccessKeyId, Signature, SignV4Params} = 
     case SignVer of
@@ -262,7 +262,8 @@ authenticate(Authorization, #sign_params{sign_ver = SignVer} = SignParams, IsCre
             SignV4Params2 = #sign_v4_params{},
             {AccessKeyId2, Signature2, SignV4Params2}
     end,
-    ?debug("authenticate/3", "Access Key: ~p, Signature: ~p, SignParams: ~p, SignV4Params: ~p", [AccessKeyId, Signature, SignParams, SignV4Params]),
+    ?debug("authenticate/3", "Access Key: ~p, Signature: ~p, Ver: ~p", [AccessKeyId, Signature, SignVer]),
+%    ?debug("authenticate/3", "Access Key: ~p, Signature: ~p, SignParams: ~p, SignV4Params: ~p", [AccessKeyId, Signature, SignParams, SignV4Params]),
     authenticate_0(AccessKeyId, Signature, SignParams, SignV4Params, IsCreateBucketOp).
 
 authenticate_0(AccessKeyId, Signature, #sign_params{bucket = <<>>} = SignParams, SignV4Params, _IsCreateBucketOp) ->
@@ -324,7 +325,7 @@ get_signature(SecretAccessKey, SignParams, SignV4Params) ->
         v4 ->
             get_signature_v4(SecretAccessKey, SignParams, SignV4Params);
         _ ->
-            get_signature_v2(SecretAccessKey, SignParams)
+            {get_signature_v2(SecretAccessKey, SignParams), <<>>, <<>>}
     end.
 
 %% @doc Get AWS signature version 4
@@ -342,7 +343,9 @@ get_signature_v4(SecretAccessKey, SignParams, SignV4Params) ->
     #sign_v4_params{credential      = Credential,
                     signed_headers  = SignedHeaders
                    } = SignV4Params,
-    URI_1       = auth_uri(Bucket, URI, RequestedURI),
+%    URI_1       = auth_uri(Bucket, URI, RequestedURI),
+    URI_1       = URI,
+    ?debug("get_signature_v4/3", "Bucket: ~p, URI: ~p, RequestedURI: ~p, ConURI: ~p", [Bucket, URI, RequestedURI, URI_1]),
     Header_1    = auth_v4_headers(Req, SignedHeaders),
     {Hash_1, _} = cowboy_req:header(<<"x-amz-content-sha256">>, Req),
     Hash_2 = case Hash_1 of
@@ -374,10 +377,13 @@ get_signature_v4(SecretAccessKey, SignParams, SignV4Params) ->
     Scope = <<Date_2/binary, "/", Region/binary, "/", Service/binary, "/aws4_request">>,
 
     RequestBin = list_to_binary(RequestHex),
-    BinToSign   = <<"AWS4-HMAC-SHA256",       "\n",
-                    Date_1/binary,            "\n",
-                    Scope/binary,             "\n",
-                    RequestBin/binary>>,
+
+    BinToSignHead   = <<Date_1/binary,            "\n",
+                        Scope/binary,             "\n">>,
+    BinToSign       = <<"AWS4-HMAC-SHA256\n",
+                        BinToSignHead/binary,
+                        RequestBin/binary>>,
+
     ?debug("get_signature_v4/3", "BinToSign: ~p", [BinToSign]),
 
     DateKey         = crypto:hmac(sha256, <<"AWS4", SecretAccessKey/binary>>, Date_2),
@@ -388,7 +394,7 @@ get_signature_v4(SecretAccessKey, SignParams, SignV4Params) ->
     Singature       = crypto:hmac(sha256, SigningKey, BinToSign),
     SingatureHex    = leo_hex:binary_to_hex(Singature),
     ?debug("get_signature_v4/3", "Singature: ~p", [SingatureHex]),
-    list_to_binary(SingatureHex).
+    {list_to_binary(SingatureHex), BinToSignHead, SigningKey}.
 
 %% @doc Get AWS signature version 2
 %% @private
@@ -557,7 +563,7 @@ authenticate_2(AuthParams) ->
 %% @doc Authenticate#3
 %% @private
 -spec(authenticate_3(AuthParams) ->
-             {ok, binary()} | {error, any()} when AuthParams::#auth_params{}).
+             {ok, binary(), binary()} | {error, any()} when AuthParams::#auth_params{}).
 authenticate_3(#auth_params{secret_access_key = SecretAccessKey,
                             access_key_id     = AccessKeyId,
                             signature         = Signature,
@@ -566,9 +572,9 @@ authenticate_3(#auth_params{secret_access_key = SecretAccessKey,
                            }) ->
     %% ?debugVal({Signature, SignParams, SignV4Params}),
     case get_signature(SecretAccessKey, SignParams, SignV4Params) of
-        Signature ->
-            {ok, AccessKeyId};
-        WrongSig ->
+        {Signature, _SignHead, _SignKey} = Ret ->
+            {ok, AccessKeyId, Ret};
+        {WrongSig, _, _} ->
             error_logger:error_msg("~p,~p,~p,~p~n",
                                    [{module, ?MODULE_STRING}, {function, "authenticate_3/1"},
                                     {line, ?LINE}, {body, WrongSig}]),

--- a/src/leo_s3_auth.erl
+++ b/src/leo_s3_auth.erl
@@ -34,20 +34,26 @@
 -include("leo_s3_user.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("stdlib/include/qlc.hrl").
+-include_lib("leo_logger/include/leo_logger.hrl").
 
 -export([start/2,
          create_table/2, put/1, bulk_put/1,
          update_providers/1,
          create_key/1, get_credential/1, has_credential/1, has_credential/2,
-         authenticate/3, get_signature/2,
+         authenticate/3, get_signature/3,
          find_all/0, checksum/0
         ]).
 
 
+-record(sign_v4_params, {credential     :: binary(),
+                         signature      :: binary(),
+                         signed_headers :: binary()
+                        }).
 -record(auth_params, {access_key_id     :: binary(),
                       secret_access_key :: binary(),
                       signature         :: binary(),
                       sign_params       :: #sign_params{},
+                      sign_v4_params    :: #sign_v4_params{},
                       auth_info         :: #auth_info{}
                      }).
 
@@ -240,25 +246,47 @@ has_credential(MasterNodes, AccessKey) ->
              {ok, binary()} | {error, any()} when Authorization::binary(),
                                                   SignParams::#sign_params{},
                                                   IsCreateBucketOp::boolean()).
-authenticate(Authorization, #sign_params{bucket = <<>>} = SignParams, _IsCreateBucketOp) ->
-    [AccWithAWS,Signature|_] = binary:split(Authorization, <<":">>),
-    <<"AWS ", AccessKeyId/binary>> = AccWithAWS,
-    authenticate_1(#auth_params{access_key_id = AccessKeyId,
-                                signature     = Signature,
-                                sign_params   = SignParams});
+authenticate(Authorization, #sign_params{sign_ver = SignVer} = SignParams, IsCreateBucketOp) ->
+    {AccessKeyId, Signature, SignV4Params} = 
+    case SignVer of
+        v4 ->
+            [<<"AWS4", _Method/binary>>, Params] = binary:split(Authorization, <<" ">>),
+            ParamList = binary:split(Params, <<",">>, [global]),
+            SignV4Params2 = extract_v4_params(ParamList),
+            [AccessKeyId2|_] = binary:split(SignV4Params2#sign_v4_params.credential, <<"/">>),
+            Signature2 = SignV4Params2#sign_v4_params.signature,
+            {AccessKeyId2, Signature2, SignV4Params2};
+        _ ->
+            [AccWithAWS,Signature2|_] = binary:split(Authorization, <<":">>),
+            <<"AWS ", AccessKeyId2/binary>> = AccWithAWS,
+            SignV4Params2 = #sign_v4_params{},
+            {AccessKeyId2, Signature2, SignV4Params2}
+    end,
+    authenticate_0(AccessKeyId, Signature, SignParams, SignV4Params, IsCreateBucketOp).
 
-authenticate(Authorization, #sign_params{bucket = Bucket} = SignParams, IsCreateBucketOp) ->
-    [AccWithAWS,Signature|_] = binary:split(Authorization, <<":">>),
-    <<"AWS ", AccessKeyId/binary>> = AccWithAWS,
+authenticate_0(AccessKeyId, Signature, #sign_params{bucket = <<>>} = SignParams, SignV4Params, _IsCreateBucketOp) ->
+    ?debug("authenticate/3", "no_bucket Access Key: ~p, Signature: ~p, SignParams: ~p", [AccessKeyId, Signature, SignParams]),
+    authenticate_1(#auth_params{access_key_id   = AccessKeyId,
+                                signature       = Signature,
+                                sign_params     = SignParams,
+                                sign_v4_params  = SignV4Params
+                               });
+
+authenticate_0(AccessKeyId, Signature, #sign_params{bucket = Bucket} = SignParams, SignV4Params, IsCreateBucketOp) ->
+    ?debug("authenticate/3", "bucket: ~p, Access Key: ~p, Signature: ~p, SignParams: ~p", [Bucket, AccessKeyId, Signature, SignParams]),
     case {leo_s3_bucket:head(AccessKeyId, Bucket), IsCreateBucketOp} of
         {ok, false} ->
-            authenticate_1(#auth_params{access_key_id = AccessKeyId,
-                                        signature     = Signature,
-                                        sign_params   = SignParams#sign_params{bucket = Bucket}});
+            authenticate_1(#auth_params{access_key_id   = AccessKeyId,
+                                        signature       = Signature,
+                                        sign_params     = SignParams#sign_params{bucket = Bucket},
+                                        sign_v4_params  = SignV4Params
+                                       });
         {not_found, true} ->
-            authenticate_1(#auth_params{access_key_id = AccessKeyId,
-                                        signature     = Signature,
-                                        sign_params   = SignParams#sign_params{bucket = Bucket}});
+            authenticate_1(#auth_params{access_key_id   = AccessKeyId,
+                                        signature       = Signature,
+                                        sign_params     = SignParams#sign_params{bucket = Bucket},
+                                        sign_v4_params  = SignV4Params
+                                       });
         _Other ->
             {error, unmatch}
     end.
@@ -287,11 +315,83 @@ authenticate(Authorization, #sign_params{bucket = Bucket} = SignParams, IsCreate
                         <<"response-content-disposition">>,
                         <<"response-content-encoding">>]).
 
-%% @doc Get AWS signature version 2
--spec(get_signature(SecretAccessKey, SignParams) ->
+-spec(get_signature(SecretAccessKey, SignParams, SignV4Params) ->
              binary() when SecretAccessKey::binary(),
-                           SignParams::#sign_params{}).
-get_signature(SecretAccessKey, SignParams) ->
+                           SignParams::#sign_params{},
+                           SignV4Params::#sign_v4_params{}).
+get_signature(SecretAccessKey, SignParams, SignV4Params) ->
+    ?debug("get_signature/3", "Key: ~p, Sign: ~p, SignV4: ~p", [SecretAccessKey, SignParams, SignV4Params]),
+    case SignParams#sign_params.sign_ver of
+        v4 ->
+            get_signature_v4(SecretAccessKey, SignParams, SignV4Params);
+        _ ->
+            get_signature_v2(SecretAccessKey, SignParams)
+    end.
+
+%% @doc Get AWS signature version 4
+%% @private
+get_signature_v4(SecretAccessKey, SignParams, SignV4Params) ->
+    #sign_params{http_verb      = HTTPVerb,
+                 date           = Date,
+                 bucket         = Bucket,
+                 raw_uri        = URI,
+                 requested_uri  = RequestedURI,
+                 query_str      = QueryStr,
+                 req            = Req,
+                 amz_headers    = AmzHeaders
+                } = SignParams,
+    #sign_v4_params{credential      = Credential,
+                    signed_headers  = SignedHeaders
+                   } = SignV4Params,
+    URI_1       = auth_uri(Bucket, URI, RequestedURI),
+    Header_1    = auth_v4_headers(Req, SignedHeaders),
+    {Hash_1, _} = cowboy_req:header(<<"x-amz-content-sha256">>, Req),
+    Hash_2 = case Hash_1 of
+                 undefined ->
+                     %% Empty Payload
+                     <<"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">>;
+                 _ ->
+                     Hash_1
+             end,
+
+    QueryStr_1 = list_to_binary(auth_v4_qs(QueryStr)),
+
+    Request_1   = <<HTTPVerb/binary,        "\n",
+                    URI_1/binary,           "\n",
+                    QueryStr_1/binary,      "\n",
+                    Header_1/binary,        "\n",
+                    SignedHeaders/binary,   "\n",
+                    Hash_2/binary>>,
+
+    ?debug("get_signature_v4/3", "Request: ~p", [Request_1]),
+    RequestHash = crypto:hash(sha256, Request_1),
+    RequestHex  = leo_hex:binary_to_hex(RequestHash),
+
+    Date_1      = auth_date(Date, AmzHeaders, v4),
+    [_AWSAccessKeyId, Date_2, Region, Service, <<"aws4_request">>] = binary:split(Credential, <<"/">>, [global]),
+
+    Scope = <<Date_2/binary, "/", Region/binary, "/", Service/binary, "/aws4_request">>,
+
+    RequestBin = list_to_binary(RequestHex),
+    BinToSign   = <<"AWS4-HMAC-SHA256",       "\n",
+                    Date_1/binary,            "\n",
+                    Scope/binary,             "\n",
+                    RequestBin/binary>>,
+    ?debug("get_signature_v4/3", "BinToSign: ~p", [BinToSign]),
+
+    DateKey         = crypto:hmac(sha256, <<"AWS4", SecretAccessKey/binary>>, Date_2),
+    DateRegionKey   = crypto:hmac(sha256, DateKey, Region),
+    DateRegionServiceKey = crypto:hmac(sha256, DateRegionKey, Service),
+    SigningKey      = crypto:hmac(sha256, DateRegionServiceKey, <<"aws4_request">>),
+
+    Singature       = crypto:hmac(sha256, SigningKey, BinToSign),
+    SingatureHex    = leo_hex:binary_to_hex(Singature),
+    ?debug("get_signature_v4/3", "Singature: ~p", [SingatureHex]),
+    list_to_binary(SingatureHex).
+
+%% @doc Get AWS signature version 2
+%% @private
+get_signature_v2(SecretAccessKey, SignParams) ->
     #sign_params{http_verb     = HTTPVerb,
                  content_md5   = ETag,
                  content_type  = ContentType,
@@ -303,7 +403,7 @@ get_signature(SecretAccessKey, SignParams) ->
                  amz_headers   = AmzHeaders
                 } = SignParams,
 
-    Date_1  = auth_date(Date, AmzHeaders),
+    Date_1  = auth_date(Date, AmzHeaders, v2),
     Sub_1   = auth_resources(AmzHeaders),
     Sub_2   = auth_sub_resources(QueryStr),
     Bucket1 = auth_bucket(URI, Bucket, QueryStr),
@@ -360,6 +460,33 @@ setup(DB, Provider) ->
                                                  provider = Provider}}),
     ok.
 
+%% @doc Extract Signature V4 Params to Record
+%% @private
+-spec(extract_v4_params(SignV4Params) ->
+             {ok, #sign_v4_params{}} | {error, any()} when SignV4Params :: list()).
+extract_v4_params(ParamList) ->
+    extract_v4_params(ParamList, #sign_v4_params{}).
+
+extract_v4_params([], #sign_v4_params{} = SignV4Params) ->
+    SignV4Params;
+extract_v4_params([Head|Rest], #sign_v4_params{} = SignV4Params) ->
+    [Key, Val|_] = binary:split(Head, <<"=">>),
+    SignV4Params2 = 
+    case Key of
+        <<"Credential">> ->
+            SignV4Params#sign_v4_params{
+              credential = Val};
+        <<"Signature">> ->
+            SignV4Params#sign_v4_params{
+              signature = Val};
+        <<"SignedHeaders">> ->
+            SignV4Params#sign_v4_params{
+              signed_headers = Val};
+        _ ->
+            SignV4Params
+    end,
+    extract_v4_params(Rest, SignV4Params2).
+
 
 %% @doc Authenticate#1
 %% @private
@@ -401,9 +528,11 @@ authenticate_2(AuthParams) ->
 authenticate_3(#auth_params{secret_access_key = SecretAccessKey,
                             access_key_id     = AccessKeyId,
                             signature         = Signature,
-                            sign_params       = SignParams}) ->
-    %% ?debugVal({Signature, SignParams}),
-    case get_signature(SecretAccessKey, SignParams) of
+                            sign_params       = SignParams,
+                            sign_v4_params    = SignV4Params
+                           }) ->
+    %% ?debugVal({Signature, SignParams, SignV4Params}),
+    case get_signature(SecretAccessKey, SignParams, SignV4Params) of
         Signature ->
             {ok, AccessKeyId};
         WrongSig ->
@@ -460,16 +589,63 @@ get_auth_info() ->
             not_found
     end.
 
+%% @doc Construct Canonical Headers
+%% @private
+auth_v4_headers(Req, SignedHeaders) ->
+    HeaderList = binary:split(SignedHeaders, <<";">>, [global]),
+    auth_v4_headers(Req, HeaderList, <<>>).
+
+auth_v4_headers(_Req, [], Acc) ->
+    Acc;
+auth_v4_headers(Req, [Head|Rest], Acc) ->
+    Val = case cowboy_req:header(Head, Req) of
+              {undefined, _} -> <<>>;
+              {Bin, _}       -> Bin
+          end,
+    auth_v4_headers(Req, Rest, <<Acc/binary, Head/binary, ":", Val/binary, "\n">>).
+
+%% @doc Consutrct Canonical Query String
+%% @private
+auth_v4_qs(QueryStr) ->
+    List = binary:split(QueryStr, <<"&">>, [global]),
+    auth_v4_qs(List, "").
+
+auth_v4_qs([], Acc) ->
+    Acc;
+auth_v4_qs([<<>>|Rest], Acc) ->
+    auth_v4_qs(Rest, Acc);
+auth_v4_qs([Head|Rest], Acc) ->
+    {Key, Val} = case binary:match(Head, <<"=">>) of
+                     nomatch ->
+                         {Head, <<>>};
+                     _ ->
+                         [Key2, Val2] = binary:split(Head, <<"=">>),
+                         {Key2, Val2}
+                 end,
+    KeyEnc = http_uri:encode(binary_to_list(Key)),
+    ValEnc = http_uri:encode(binary_to_list(Val)),
+    case Acc of
+        "" ->
+            auth_v4_qs(Rest, lists:append([KeyEnc, "=", ValEnc]));
+        Acc ->
+            auth_v4_qs(Rest, lists:append([Acc, "&", KeyEnc, "=", ValEnc]))
+    end.
 
 %% @doc Retrieve date
 %% @private
--spec(auth_date(Date, CannonocalizedResources) ->
+-spec(auth_date(Date, CannonocalizedResources, SignVer) ->
              binary() when Date::binary(),
-                           CannonocalizedResources::list()).
-auth_date(Date, CannonocalizedResources) ->
+                           CannonocalizedResources::list(),
+                           SignVer::atom()).
+auth_date(Date, CannonocalizedResources, SignVer) ->
     case lists:keysearch("x-amz-date", 1, CannonocalizedResources) of
-        {value, _} ->
-            <<>>;
+        {value, {"x-amz-date", AmzDate}} ->
+            case SignVer of
+                v4 ->
+                    list_to_binary(AmzDate);
+                _ ->
+                    <<>>
+            end;
         false ->
             << Date/binary >>
     end.

--- a/test/leo_s3_auth_tests.erl
+++ b/test/leo_s3_auth_tests.erl
@@ -52,7 +52,13 @@ auth_test_() ->
                            fun authenticate_7_/1,
                            fun authenticate_8_/1,
                            fun authenticate_9_/1,
-                           fun authenticate_10_/1
+                           fun authenticate_10_/1,
+                           fun authenticate_v4_1/1,
+                           fun authenticate_v4_2/1,
+                           fun authenticate_v4_3/1,
+                           fun authenticate_v4_4/1,
+                           fun authenticate_v4_5/1,
+                           fun authenticate_v4_6/1
                           ]]}.
 
 setup() ->
@@ -122,10 +128,10 @@ mnesia_suite_(_) ->
                                raw_uri       = <<"/photos/puppy.jpg">>,
                                requested_uri = <<"/photos/puppy.jpg">>
                               },
-    Signature0 = leo_s3_auth:get_signature(SecretAccessKey, SignParams0),
+    {Signature0, _, _} = leo_s3_auth:get_signature(SecretAccessKey, SignParams0, #sign_v4_params{}),
     Authorization0 = << <<"AWS ">>/binary, AccessKeyId/binary, <<":">>/binary, Signature0/binary >>,
 
-    {ok, AccessKeyId} = leo_s3_auth:authenticate(Authorization0, SignParams0, false),
+    {ok, AccessKeyId, _} = leo_s3_auth:authenticate(Authorization0, SignParams0, false),
     {ok, Credential}  = leo_s3_auth:get_credential(AccessKeyId),
     ?assertEqual(AccessKeyId,     Credential#credential.access_key_id),
     ?assertEqual(SecretAccessKey, Credential#credential.secret_access_key),
@@ -168,10 +174,10 @@ mnesia_suite_(_) ->
                                raw_uri       = <<"/">>,
                                requested_uri = <<"/">>
                               },
-    Signature1 = leo_s3_auth:get_signature(SecretAccessKey, SignParams1),
+    {Signature1, _, _} = leo_s3_auth:get_signature(SecretAccessKey, SignParams1, #sign_v4_params{}),
     Authorization2 = << <<"AWS ">>/binary, AccessKeyId/binary, <<":">>/binary, Signature1/binary >>,
 
-    {ok, AccessKeyId} = leo_s3_auth:authenticate(Authorization2, SignParams1, false),
+    {ok, AccessKeyId, _} = leo_s3_auth:authenticate(Authorization2, SignParams1, false),
 
     %% check checksum
     {ok, Checksum} = leo_s3_auth:checksum(),
@@ -242,11 +248,11 @@ ets_suite_(_) ->
                               raw_uri       = <<"/photos/puppy.jpg">>,
                               requested_uri = <<"/photos/puppy.jpg">>
                              },
-    Signature0 = leo_s3_auth:get_signature(SecretAccessKey, SignParams),
+    {Signature0, _, _} = leo_s3_auth:get_signature(SecretAccessKey, SignParams, #sign_v4_params{}),
     Authorization0 = << <<"AWS ">>/binary, AccessKeyId/binary, <<":">>/binary, Signature0/binary >>,
     Authorization1 = << <<"AWS ">>/binary, AccessKeyId/binary, <<":EXAMPLE">>/binary >>,
 
-    {ok, AccessKeyId} = leo_s3_auth:authenticate(Authorization0, SignParams, false),
+    {ok, AccessKeyId, _} = leo_s3_auth:authenticate(Authorization0, SignParams, false),
     {error,unmatch} = leo_s3_auth:authenticate(Authorization1, SignParams, false),
 
     {ok, #credential{access_key_id     = AccessKeyId,
@@ -312,7 +318,7 @@ authenticate_0_(_) ->
                               requested_uri = <<"/photos/puppy.jpg">>
                              },
 
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"bWq2s1WEIj+Ydj0vQ697zp+IXMU=">>, Ret),
     ok.
 
@@ -345,7 +351,7 @@ authenticate_1_(_) ->
                               requested_uri = <<"/photos/puppy.jpg">>
                              },
 
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"MyyxeRY7whkBe+bq8fHCL/2kKUg=">>, Ret),
     ok.
 
@@ -377,7 +383,7 @@ authenticate_2_(_) ->
                               requested_uri = <<"/">>,
                               query_str     = <<"?prefix=photos&max-keys=50&marker=puppy">>
                              },
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"htDYFYduRNen8P9ZfE/s9SuKy0U=">>, Ret),
     ok.
 
@@ -408,7 +414,7 @@ authenticate_3_(_) ->
                               requested_uri = <<"/">>,
                               query_str     = <<"?acl">>
                              },
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"c2WLPFtWHVgbEmeEG93a4cG37dM=">>, Ret),
     ok.
 
@@ -443,7 +449,7 @@ authenticate_4_(_) ->
                               amz_headers   = [
                                               {"x-amz-date", "Tue, 27 Mar 2007 21:20:26 +0000"}]
                              },
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"R4dJ53KECjStyBO5iTBJZ4XVOaI=">>, Ret),
     %% ?assertEqual(<<"9b2sXq0KfxsxHtdZkzx/9Ngqyh8=">>, Ret),
     ok.
@@ -495,8 +501,8 @@ authenticate_5_(_) ->
                                                 {"x-amz-Meta-ReviewedBy", "jane@johnsmith.net"},
                                                 {"x-amz-Meta-FileChecksum","0x02661779"},
                                                 {"x-amz-Meta-ChecksumAlgorithm", "crc32"}]},
-    Ret1 = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams1),
-    ?assertEqual(<<"ilyl83RwaSoYIEdixDQcA4OnAnc=">>, Ret1),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams1, #sign_v4_params{}),
+    ?assertEqual(<<"ilyl83RwaSoYIEdixDQcA4OnAnc=">>, Ret),
     ok.
 
 
@@ -524,7 +530,7 @@ authenticate_6_(_) ->
                               raw_uri       = <<"/">>,
                               requested_uri = <<"/">>,
                               amz_headers   = []},
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"qGdzdERIC03wnaRNKh6OqZehG9s=">>, Ret),
     ok.
 
@@ -552,7 +558,7 @@ authenticate_7_(_) ->
                               raw_uri       = <<"/dictionary/fran%C3%A7ais/pr%c3%a9f%c3%a8re">>,
                               requested_uri = <<"/dictionary/fran%C3%A7ais/pr%c3%a9f%c3%a8re">>,
                               amz_headers   = []},
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"DNEZGsoieTZ92F3bUfSPQcbGmlM=">>, Ret),
     ok.
 
@@ -583,7 +589,7 @@ authenticate_8_(_) ->
                               requested_uri = <<"/path/to/file">>,
                               query_str     = <<"?versionid=9">>
                              },
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"ld6nhMmeUif8N/zae7DGfB5xYiI=">>, Ret),
     ok.
 
@@ -616,7 +622,7 @@ authenticate_9_(_) ->
                               requested_uri = <<"/path/to/file">>,
                               query_str     = <<"?acl&versionid=9">>
                              },
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"b3zx5W2PwpsnI/raaZH7heh1NH0=">>, Ret),
     ok.
 
@@ -650,10 +656,292 @@ authenticate_10_(_) ->
                               requested_uri = <<"/path/to/file">>,
                               query_str     = <<"?response-cache-control=No-cache&response-content-disposition=attachment%3B%20filename%3Dtesting.txt&response-content-encoding=x-gzip&response-content-language=mi%2C%20en&response-expires=Thu%2C%2001%20Dec%201994%2016:00:00%20GMT">>
                              },
-    Ret = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams),
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, #sign_v4_params{}),
     ?assertEqual(<<"IjeV85YN0SCCw26yHd8DXCIvBjk=">>, Ret),
     ok.
 
+-define(AWSSecretAccessKeyV4, <<"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY">>).
+authenticate_v4_1(_) ->
+    %% == PARAMS ==
+    %% POST https://iam.amazonaws.com/ HTTP/1.1
+    %% host: iam.amazonaws.com
+    %% Content-type: application/x-www-form-urlencoded; charset=utf-8
+    %% x-amz-date: 20110909T233600Z
+    %%
+    %% Action=ListUsers&Version=2010-05-08
 
+    %% == Canonical Request ==
+    %% POST
+    %% /
+    %%
+    %% content-type:application/x-www-form-urlencoded; charset=utf-8
+    %% host:iam.amazonaws.com
+    %% x-amz-date:20110909T233600Z
+    %%
+    %% content-type;host;x-amz-date
+    %% b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
+
+    %% == StringToSign ==
+    %% AWS4-HMAC-SHA256
+    %% 20110909T233600Z
+    %% 20110909/us-east-1/iam/aws4_request
+    %% 3511de7e95d28ecd39e9513b642aee07e54f4941150d8df8bf94b328ef7e55e2
+
+    %% == Signing Key ==
+    %% <<152,241,216,137,254,196,244,66,26,220,82,43,171,12,225,248,46,105,41,194,98,237,21,229,169,76,144,239,209,227,176,231>>
+
+    Headers     = [{<<"content-type">>, <<"application/x-www-form-urlencoded; charset=utf-8">>},
+                   {<<"host">>, <<"iam.amazonaws.com">>},
+                   {<<"x-amz-date">>, <<"20110909T233600Z">>},
+                   {<<"x-amz-content-sha256">>, <<"b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2">>}
+                  ],
+    QueryStr    = <<>>,
+    SignParams  = #sign_params{http_verb     = <<"POST">>,
+                               date          = <<>>,
+                               raw_uri       = <<"/">>,
+                               headers       = Headers,
+                               sign_ver      = v4,
+                               query_str     = QueryStr
+                              },
+    SignV4Params = #sign_v4_params{credential       = <<"AKIAIOSFODNN7EXAMPLE/20110909/us-east-1/iam/aws4_request">>,
+                                   signed_headers   = <<"content-type;host;x-amz-date">>
+                                  },
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKeyV4, SignParams, SignV4Params),
+    ?assertEqual(<<"ced6826de92d2bdeed8f846f0bf508e8559e98e4b0199114b84c54174deb456c">>, Ret),
+    ok.
+
+authenticate_v4_2(_) ->
+    ok = leo_s3_auth:start(master, []),
+    ok = leo_s3_auth:create_table(ram_copies, [node()]),
+
+    {ok, Keys} = leo_s3_auth:create_key(?USER_ID),
+    AccessKeyId     = proplists:get_value(access_key_id,     Keys),
+    SecretAccessKey = proplists:get_value(secret_access_key, Keys),
+
+    Headers     = [{<<"content-type">>, <<"application/x-www-form-urlencoded; charset=utf-8">>},
+                   {<<"host">>, <<"iam.amazonaws.com">>},
+                   {<<"x-amz-date">>, <<"20110909T233600Z">>},
+                   {<<"x-amz-content-sha256">>, <<"b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2">>}
+                  ],
+    QueryStr    = <<>>,
+    SignParams  = #sign_params{http_verb     = <<"POST">>,
+                               date          = <<>>,
+                               raw_uri       = <<"/">>,
+                               headers       = Headers,
+                               sign_ver      = v4,
+                               query_str     = QueryStr
+                              },
+    Credential  = <<AccessKeyId/binary, "/20110909/us-east-1/iam/aws4_request">>,
+    SignedHeaders = <<"content-type;host;x-amz-date">>,
+    SignV4Params = #sign_v4_params{credential       = <<AccessKeyId/binary, "/20110909/us-east-1/iam/aws4_request">>,
+                                   signed_headers   = <<"content-type;host;x-amz-date">>
+                                  },
+    {Signature, _, _} = leo_s3_auth:get_signature(SecretAccessKey, SignParams, SignV4Params),
+    Authorization = <<"AWS4-HMAC-SHA256 ",
+                      "Credential=", Credential/binary, ", ", 
+                      "SignedHeaders=", SignedHeaders/binary, ", ",
+                      "Signature=", Signature/binary>>,
+    {ok, AccessKeyId, _} = leo_s3_auth:authenticate(Authorization, SignParams, false),
+    ok.
+
+%% @doc Authorization Header TEST (Signature V4)
+%% @ref <http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html>
+
+%% @doc GET Object
+authenticate_v4_3(_) ->
+    %% == PARAMS ==
+    %% GET /test.txt HTTP/1.1
+    %% Host: examplebucket.s3.amazonaws.com
+    %% Date: Fri, 24 May 2013 00:00:00 GMT
+    %% Authorization: SignatureToBeCalculated
+    %% Range: bytes=0-9 
+    %% x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    %% x-amz-date: 20130524T000000Z 
+
+    %% == Canonical Request ==
+    %% GET
+    %% /test.txt
+    %%
+    %% host:examplebucket.s3.amazonaws.com
+    %% range:bytes=0-9
+    %% x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    %% x-amz-date:20130524T000000Z
+    %%
+    %% host;range;x-amz-content-sha256;x-amz-date
+    %% e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  
+
+    %% == StringToSign ==
+    %% AWS4-HMAC-SHA256
+    %% 20130524T000000Z
+    %% 20130524/us-east-1/s3/aws4_request
+    %% 7344ae5b7ee6c3e7e6b0fe0640412a37625d1fbfff95c48bbb2dc43964946972
+
+    Headers     = [
+                   {<<"host">>, <<"examplebucket.s3.amazonaws.com">>},
+                   {<<"range">>, <<"bytes=0-9">>},
+                   {<<"x-amz-date">>, <<"20130524T000000Z">>},
+                   {<<"x-amz-content-sha256">>, <<"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">>}
+                  ],
+    QueryStr    = <<>>,
+    SignParams  = #sign_params{http_verb     = <<"GET">>,
+                               date          = <<>>,
+                               raw_uri       = <<"/test.txt">>,
+                               headers       = Headers,
+                               sign_ver      = v4,
+                               query_str     = QueryStr
+                              },
+    SignV4Params = #sign_v4_params{credential       = <<?AWSAccessKeyId/binary, "/20130524/us-east-1/s3/aws4_request">>,
+                                   signed_headers   = <<"host;range;x-amz-content-sha256;x-amz-date">>
+                                  },
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, SignV4Params),
+    ?assertEqual(<<"f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41">>, Ret),
+    ok.
+
+%% @doc PUT Object
+authenticate_v4_4(_) ->
+    %% == PARAMS ==
+    %% PUT test$file.txt HTTP/1.1
+    %% Host: examplebucket.s3.amazonaws.com
+    %% Date: Fri, 24 May 2013 00:00:00 GMT
+    %%
+    %% Authorization: SignatureToBeCalculated
+    %% x-amz-date: 20130524T000000Z 
+    %% x-amz-storage-class: REDUCED_REDUNDANCY
+    %% x-amz-content-sha256: 44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
+    %%
+    %% <Payload>
+
+    %% == Canonical Request ==
+    %% PUT
+    %% /test%24file.text
+    %%
+    %% date:Fri, 24 May 2013 00:00:00 GMT
+    %% host:examplebucket.s3.amazonaws.com
+    %% x-amz-content-sha256:44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
+    %% x-amz-date:20130524T000000Z
+    %% x-amz-storage-class:REDUCED_REDUNDANCY
+    %%
+    %% date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class
+    %% 44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072
+
+    %% == StringToSign ==
+    %% AWS4-HMAC-SHA256
+    %% 20130524T000000Z
+    %% 20130524/us-east-1/s3/aws4_request
+    %% 9e0e90d9c76de8fa5b200d8c849cd5b8dc7a3be3951ddb7f6a76b4158342019d
+
+    Headers     = [
+                   {<<"date">>, <<"Fri, 24 May 2013 00:00:00 GMT">>},
+                   {<<"host">>, <<"examplebucket.s3.amazonaws.com">>},
+                   {<<"x-amz-content-sha256">>, <<"44ce7dd67c959e0d3524ffac1771dfbba87d2b6b4b4e99e42034a8b803f8b072">>},
+                   {<<"x-amz-date">>, <<"20130524T000000Z">>},
+                   {<<"x-amz-storage-class">>, <<"REDUCED_REDUNDANCY">>}
+                  ],
+    QueryStr    = <<>>,
+    SignParams  = #sign_params{http_verb     = <<"PUT">>,
+                               date          = <<"Fri, 24 May 2013 00:00:00 GMT">>,
+                               raw_uri       = <<"/test%24file.text">>,
+                               headers       = Headers,
+                               sign_ver      = v4,
+                               query_str     = QueryStr
+                              },
+    SignV4Params = #sign_v4_params{credential       = <<?AWSAccessKeyId/binary, "/20130524/us-east-1/s3/aws4_request">>,
+                                   signed_headers   = <<"date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class">>
+                                  },
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, SignV4Params),
+    ?assertEqual(<<"98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd">>, Ret),
+    ok.
+
+%% @doc GET Bucket Lifecycle
+authenticate_v4_5(_) ->
+    %% == PARAMS ==
+    %% GET ?lifecycle HTTP/1.1
+    %% Host: examplebucket.s3.amazonaws.com
+    %% Authorization: SignatureToBeCalculated
+    %% x-amz-date: 20130524T000000Z 
+    %% x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+    %% == Canonical Request ==
+    %% GET
+    %% /
+    %% lifecycle=
+    %% host:examplebucket.s3.amazonaws.com
+    %% x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    %% x-amz-date:20130524T000000Z
+    %%
+    %% host;x-amz-content-sha256;x-amz-date
+    %% e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+    %% == StringToSign ==
+    %% AWS4-HMAC-SHA256
+    %% 20130524T000000Z
+    %% 20130524/us-east-1/s3/aws4_request
+    %% 9766c798316ff2757b517bc739a67f6213b4ab36dd5da2f94eaebf79c77395ca
+
+    Headers     = [
+                   {<<"host">>, <<"examplebucket.s3.amazonaws.com">>},
+                   {<<"x-amz-date">>, <<"20130524T000000Z">>},
+                   {<<"x-amz-content-sha256">>, <<"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">>}
+                  ],
+    QueryStr    = <<"lifecycle=">>,
+    SignParams  = #sign_params{http_verb     = <<"GET">>,
+                               date          = <<>>,
+                               raw_uri       = <<"/">>,
+                               headers       = Headers,
+                               sign_ver      = v4,
+                               query_str     = QueryStr
+                              },
+    SignV4Params = #sign_v4_params{credential       = <<?AWSAccessKeyId/binary, "/20130524/us-east-1/s3/aws4_request">>,
+                                   signed_headers   = <<"host;x-amz-content-sha256;x-amz-date">>
+                                  },
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, SignV4Params),
+    ?assertEqual(<<"fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543">>, Ret),
+    ok.
+
+%% @doc Get Bucket (List Objects)
+authenticate_v4_6(_) ->
+    %% == PARAMS ==
+    %% GET ?max-keys=2&prefix=J HTTP/1.1
+    %% Host: examplebucket.s3.amazonaws.com
+    %% Authorization: SignatureToBeCalculated
+    %% x-amz-date: 20130524T000000Z 
+    %% x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+    %% == Canonical Request ==
+    %% GET
+    %% /
+    %% max-keys=2&prefix=J
+    %% host:examplebucket.s3.amazonaws.com
+    %% x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    %% x-amz-date:20130524T000000Z
+    %%
+    %% host;x-amz-content-sha256;x-amz-date
+    %% e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+    %% == StringToSign ==
+    %% AWS4-HMAC-SHA256
+    %% 20130524T000000Z
+    %% 20130524/us-east-1/s3/aws4_request
+    %% df57d21db20da04d7fa30298dd4488ba3a2b47ca3a489c74750e0f1e7df1b9b7
+
+    Headers     = [
+                   {<<"host">>, <<"examplebucket.s3.amazonaws.com">>},
+                   {<<"x-amz-date">>, <<"20130524T000000Z">>},
+                   {<<"x-amz-content-sha256">>, <<"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855">>}
+                  ],
+    QueryStr    = <<"max-keys=2&prefix=J">>,
+    SignParams  = #sign_params{http_verb     = <<"GET">>,
+                               date          = <<>>,
+                               raw_uri       = <<"/">>,
+                               headers       = Headers,
+                               sign_ver      = v4,
+                               query_str     = QueryStr
+                              },
+    SignV4Params = #sign_v4_params{credential       = <<?AWSAccessKeyId/binary, "/20130524/us-east-1/s3/aws4_request">>,
+                                   signed_headers   = <<"host;x-amz-content-sha256;x-amz-date">>
+                                  },
+    {Ret, _, _} = leo_s3_auth:get_signature(?AWSSecretAccessKey, SignParams, SignV4Params),
+    ?assertEqual(<<"34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7">>, Ret),
+    ok.
 
 -endif.


### PR DESCRIPTION
### Brief Description
- Related to issue leo-project/leofs#283 leo-project/leofs#373

The flow is similar to Version 2 with two major differences
- Payload SHA-256 is used for Signature
- Chunked Upload
### Related Pull Requests
- https://github.com/leo-project/leo_gateway/pull/24
- https://github.com/leo-project/leo_s3_libs/pull/2
- https://github.com/leo-project/leo_commons/pull/3
### Work in Progress
- Unit Test
### Using Authorization Header
#### Checksum Precomputed

http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
- SHA-256 Checksum Provided in HTTP Header `x-amz-content-sha256`
- Small Modification
#### Amazon Chunked Upload

http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
- "Rolling" Checksum of Chunks
### Using Query Parameters

http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
### Using HTTP Post

http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
