### PR TITLE
Return already_yours and not_found for bucket operations

### DIFF
--- a/src/leo_s3_auth.erl
+++ b/src/leo_s3_auth.erl
@@ -303,6 +303,10 @@ authenticate_1(AccessKeyId, Signature, #sign_params{bucket = Bucket} = SignParam
                                         signature = Signature,
                                         sign_params = SignParams#sign_params{bucket = Bucket},
                                         sign_v4_params = SignV4Params});
+        {ok, true} ->
+            {error, already_yours};
+        {not_found, false} ->
+            {error, not_found};
         {not_found, true} ->
             authenticate_2(#auth_params{access_key_id = AccessKeyId,
                                         signature = Signature,


### PR DESCRIPTION
### Description

To return more precise error message to user for bucket operations
1. Create an already owned bucket
2. Get an non-existent bucket
### Related Issue

https://github.com/leo-project/leofs/issues/409
### Related PR

https://github.com/leo-project/leo_s3_libs/pull/3
https://github.com/leo-project/leo_gateway/pull/33
